### PR TITLE
feat(scoring): implement poker hand scoring subsystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ list(FILTER SOURCES EXCLUDE REGEX "src/main.cpp")
 add_executable(PokerGame src/main.cpp ${SOURCES})
 
 # Tambahkan target Testing
-add_executable(TestRunner tests/test_checkers.cpp ${SOURCES})
+add_executable(TestRunner tests/test_checkers.cpp tests/test_scoring.cpp ${SOURCES})
 
 # (Opsional) Mengatur output direktori agar rapi
 set_target_properties(PokerGame TestRunner PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")

--- a/src/GameManage.cpp
+++ b/src/GameManage.cpp
@@ -16,7 +16,7 @@ GameManager* GameManager::GetInstance() {
 GameManager::GameManager() {
     handGenerator = new HandGenerator();
     // Default strategies
-    scoringRule = std::make_unique<ScoringRule>(std::make_unique<StandardScoring>());
+    scoringRule = std::make_unique<ScoringRule>(std::make_unique<BaseScoringRule>());
     blindRule = std::make_unique<BlindRule>(std::make_unique<SmallBlind>());
     rewardRule = std::make_unique<RewardRule>(std::make_unique<StandardReward>());
 }

--- a/src/ScoringRule.cpp
+++ b/src/ScoringRule.cpp
@@ -1,15 +1,19 @@
 #include "lib/ScoringRule.h"
 
-int StandardScoring::CalculateScore(const std::string& handName, int baseScore) {
-    return baseScore;
+PlayedHandResult BaseScoringRule::Calculate(PokerHandType type, const HandScoreTable& table) {
+    auto it = table.find(type);
+    if (it != table.end()) {
+        const auto& data = it->second;
+        return PlayedHandResult(type, data.baseChips, data.baseMult, data.level);
+    }
+    return PlayedHandResult(type, 0, 0, 0);
 }
 
-int DoubleScoring::CalculateScore(const std::string& handName, int baseScore) {
-    return baseScore * 2;
-}
+ScoringRule::ScoringRule(std::unique_ptr<IScoringRule> strat) : strategy(std::move(strat)) {}
 
-ScoringRule::ScoringRule(std::unique_ptr<IScoringStrategy> strat) : strategy(std::move(strat)) {}
-
-int ScoringRule::calculateScore(const std::string& handName, int baseScore) {
-    return strategy ? strategy->CalculateScore(handName, baseScore) : baseScore;
+PlayedHandResult ScoringRule::calculateScore(PokerHandType type, const HandScoreTable& table) {
+    if (strategy) {
+        return strategy->Calculate(type, table);
+    }
+    return PlayedHandResult(type, 0, 0, 0);
 }

--- a/src/checker/FiveOfKindChecker.cpp
+++ b/src/checker/FiveOfKindChecker.cpp
@@ -1,13 +1,14 @@
 #include <iostream>
 #include "../lib/checker/FiveOfKindChecker.h"
 #include "../lib/PokerHandUtils.h"
+#include "../lib/PokerHandType.h"
 
 ChosenHand FiveOfKindChecker::Check(const Hand& hand)
 {
     if (IsFiveOfKind(hand))
     {
         std::cout << "Detected FIVE OF A KIND\n";
-        return ChosenHand("Five of a Kind", 1000);
+        return ChosenHand("Five of a Kind", PokerHandType::FiveOfKind, 1000);
     }
     return ChosenHand();
 }

--- a/src/checker/FlushChecker.cpp
+++ b/src/checker/FlushChecker.cpp
@@ -1,13 +1,14 @@
 #include <iostream>
 #include "../lib/checker/FlushChecker.h"
 #include "../lib/PokerHandUtils.h"
+#include "../lib/PokerHandType.h"
 
 ChosenHand FlushChecker::Check(const Hand& hand)
 {
     if (IsFlush(hand))
     {
         std::cout << "Detected FLUSH\n";
-        return ChosenHand("Flush", 80);
+        return ChosenHand("Flush", PokerHandType::Flush, 80);
     }
     return ChosenHand();
 }

--- a/src/checker/FlushHouseChecker.cpp
+++ b/src/checker/FlushHouseChecker.cpp
@@ -1,13 +1,14 @@
 #include <iostream>
 #include "../lib/checker/FlushHouseChecker.h"
 #include "../lib/PokerHandUtils.h"
+#include "../lib/PokerHandType.h"
 
 ChosenHand FlushHouseChecker::Check(const Hand& hand)
 {
     if (IsFlushHouse(hand))
     {
         std::cout << "Detected FLUSH HOUSE\n";
-        return ChosenHand("Flush House", 140);
+        return ChosenHand("Flush House", PokerHandType::FlushHouse, 140);
     }
     return ChosenHand();
 }

--- a/src/checker/FourOfKindChecker.cpp
+++ b/src/checker/FourOfKindChecker.cpp
@@ -1,13 +1,14 @@
 #include <iostream>
 #include "../lib/checker/FourOfKindChecker.h"
 #include "../lib/PokerHandUtils.h"
+#include "../lib/PokerHandType.h"
 
 ChosenHand FourOfKindChecker::Check(const Hand& hand)
 {
     if (IsFourOfKind(hand))
     {
         std::cout << "Detected FOUR OF A KIND\n";
-        return ChosenHand("Four of a Kind", 150);
+        return ChosenHand("Four of a Kind", PokerHandType::FourOfKind, 150);
     }
     return ChosenHand();
 }

--- a/src/checker/FullHouseChecker.cpp
+++ b/src/checker/FullHouseChecker.cpp
@@ -1,13 +1,14 @@
 #include <iostream>
 #include "../lib/checker/FullHouseChecker.h"
 #include "../lib/PokerHandUtils.h"
+#include "../lib/PokerHandType.h"
 
 ChosenHand FullHouseChecker::Check(const Hand& hand)
 {
     if (IsFullHouse(hand))
     {
         std::cout << "Detected FULL HOUSE\n";
-        return ChosenHand("Full House", 100);
+        return ChosenHand("Full House", PokerHandType::FullHouse, 100);
     }
     return ChosenHand();
 }

--- a/src/checker/HighCardChecker.cpp
+++ b/src/checker/HighCardChecker.cpp
@@ -1,13 +1,14 @@
 #include <iostream>
 #include "../lib/checker/HighCardChecker.h"
 #include "../lib/PokerHandUtils.h"
+#include "../lib/PokerHandType.h"
 
 ChosenHand HighCardChecker::Check(const Hand& hand)
 {
     if (IsHighCard(hand))
     {
         std::cout << "Detected HIGH CARD\n";
-        return ChosenHand("High Card", 10);
+        return ChosenHand("High Card", PokerHandType::HighCard, 10);
     }
     return ChosenHand();
 }

--- a/src/checker/PairChecker.cpp
+++ b/src/checker/PairChecker.cpp
@@ -1,13 +1,14 @@
 #include <iostream>
 #include "../lib/checker/PairChecker.h"
 #include "../lib/PokerHandUtils.h"
+#include "../lib/PokerHandType.h"
 
 ChosenHand PairChecker::Check(const Hand& hand)
 {
     if (IsPair(hand))
     {
         std::cout << "Detected PAIR\n";
-        return ChosenHand("Pair", 20);
+        return ChosenHand("Pair", PokerHandType::Pair, 20);
     }
     return ChosenHand();
 }

--- a/src/checker/RoyalFlushChecker.cpp
+++ b/src/checker/RoyalFlushChecker.cpp
@@ -1,13 +1,14 @@
 #include <iostream>
 #include "../lib/checker/RoyalFlushChecker.h"
 #include "../lib/PokerHandUtils.h"
+#include "../lib/PokerHandType.h"
 
 ChosenHand RoyalFlushChecker::Check(const Hand& hand)
 {
     if (IsRoyalFlush(hand))
     {
         std::cout << "Detected ROYAL FLUSH\n";
-        return ChosenHand("Royal Flush", 500);
+        return ChosenHand("Royal Flush", PokerHandType::RoyalFlush, 500);
     }
     return ChosenHand();
 }

--- a/src/checker/StraightChecker.cpp
+++ b/src/checker/StraightChecker.cpp
@@ -1,13 +1,14 @@
 #include <iostream>
 #include "../lib/checker/StraightChecker.h"
 #include "../lib/PokerHandUtils.h"
+#include "../lib/PokerHandType.h"
 
 ChosenHand StraightChecker::Check(const Hand& hand)
 {
     if (IsStraight(hand))
     {
         std::cout << "Detected STRAIGHT\n";
-        return ChosenHand("Straight", 60);
+        return ChosenHand("Straight", PokerHandType::Straight, 60);
     }
     return ChosenHand();
 }

--- a/src/checker/StraightFlushChecker.cpp
+++ b/src/checker/StraightFlushChecker.cpp
@@ -1,13 +1,14 @@
 #include <iostream>
 #include "../lib/checker/StraightFlushChecker.h"
 #include "../lib/PokerHandUtils.h"
+#include "../lib/PokerHandType.h"
 
 ChosenHand StraightFlushChecker::Check(const Hand& hand)
 {
     if (IsStraightFlush(hand))
     {
         std::cout << "Detected STRAIGHT FLUSH\n";
-        return ChosenHand("Straight Flush", 250);
+        return ChosenHand("Straight Flush", PokerHandType::StraightFlush, 250);
     }
     return ChosenHand();
 }

--- a/src/checker/ThreeOfKindChecker.cpp
+++ b/src/checker/ThreeOfKindChecker.cpp
@@ -1,13 +1,14 @@
 #include <iostream>
 #include "../lib/checker/ThreeOfKindChecker.h"
 #include "../lib/PokerHandUtils.h"
+#include "../lib/PokerHandType.h"
 
 ChosenHand ThreeOfKindChecker::Check(const Hand& hand)
 {
     if (IsThreeOfKind(hand))
     {
         std::cout << "Detected THREE OF A KIND\n";
-        return ChosenHand("Three of a Kind", 40);
+        return ChosenHand("Three of a Kind", PokerHandType::ThreeOfKind, 40);
     }
     return ChosenHand();
 }

--- a/src/checker/TwoPairChecker.cpp
+++ b/src/checker/TwoPairChecker.cpp
@@ -1,13 +1,14 @@
 #include <iostream>
 #include "../lib/checker/TwoPairChecker.h"
 #include "../lib/PokerHandUtils.h"
+#include "../lib/PokerHandType.h"
 
 ChosenHand TwoPairChecker::Check(const Hand& hand)
 {
     if (IsTwoPair(hand))
     {
         std::cout << "Detected TWO PAIR\n";
-        return ChosenHand("Two Pair", 30);
+        return ChosenHand("Two Pair", PokerHandType::TwoPair, 30);
     }
     return ChosenHand();
 }

--- a/src/lib/ChosenHand.h
+++ b/src/lib/ChosenHand.h
@@ -2,13 +2,16 @@
 #define CHOSENHAND_H
 
 #include <string>
+#include "PokerHandType.h"
 
 struct ChosenHand {
     std::string handName;
+    PokerHandType handType;
     int baseScore;
 
-    ChosenHand() : handName(""), baseScore(0) {}
-    ChosenHand(std::string name, int score) : handName(name), baseScore(score) {}
+    ChosenHand() : handName(""), handType(PokerHandType::HighCard), baseScore(0) {}
+    ChosenHand(std::string name, int score) : handName(name), handType(PokerHandType::HighCard), baseScore(score) {}
+    ChosenHand(std::string name, PokerHandType type, int score) : handName(name), handType(type), baseScore(score) {}
 
     bool isValid() const {
         return !handName.empty();

--- a/src/lib/HandScore.h
+++ b/src/lib/HandScore.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "PokerHandType.h"
+#include <unordered_map>
+
+struct HandScoreData {
+    int baseChips;
+    int baseMult;
+    int level;
+
+    HandScoreData() : baseChips(0), baseMult(0), level(1) {}
+    HandScoreData(int chips, int mult, int lvl = 1) 
+        : baseChips(chips), baseMult(mult), level(lvl) {}
+};
+
+struct PlayedHandResult {
+    const PokerHandType handType;
+    const int chips;
+    const int mult;
+    const int level;
+    const int finalScore;
+
+    PlayedHandResult(PokerHandType type, int c, int m, int l)
+        : handType(type), chips(c), mult(m), level(l), finalScore(c * m) {}
+};
+
+using HandScoreTable = std::unordered_map<PokerHandType, HandScoreData>;

--- a/src/lib/PokerHandType.h
+++ b/src/lib/PokerHandType.h
@@ -1,0 +1,16 @@
+#pragma once
+
+enum class PokerHandType {
+    HighCard,
+    Pair,
+    TwoPair,
+    ThreeOfKind,
+    Straight,
+    Flush,
+    FullHouse,
+    FourOfKind,
+    StraightFlush,
+    RoyalFlush,
+    FiveOfKind,
+    FlushHouse
+};

--- a/src/lib/ScoringRule.h
+++ b/src/lib/ScoringRule.h
@@ -1,28 +1,23 @@
 #pragma once
-#include <string>
+#include "HandScore.h"
 #include <memory>
 
-class IScoringStrategy {
+class IScoringRule {
 public:
-    virtual ~IScoringStrategy() = default;
-    virtual int CalculateScore(const std::string& handName, int baseScore) = 0;
+    virtual ~IScoringRule() = default;
+    virtual PlayedHandResult Calculate(PokerHandType type, const HandScoreTable& table) = 0;
 };
 
-class StandardScoring : public IScoringStrategy {
+class BaseScoringRule : public IScoringRule {
 public:
-    int CalculateScore(const std::string& handName, int baseScore) override;
-};
-
-class DoubleScoring : public IScoringStrategy {
-public:
-    int CalculateScore(const std::string& handName, int baseScore) override;
+    PlayedHandResult Calculate(PokerHandType type, const HandScoreTable& table) override;
 };
 
 class ScoringRule {
 private:
-    std::unique_ptr<IScoringStrategy> strategy;
+    std::unique_ptr<IScoringRule> strategy;
 
 public:
-    ScoringRule(std::unique_ptr<IScoringStrategy> strat);
-    int calculateScore(const std::string& handName, int baseScore);
+    ScoringRule(std::unique_ptr<IScoringRule> strat);
+    PlayedHandResult calculateScore(PokerHandType type, const HandScoreTable& table);
 };

--- a/tests/test_checkers.cpp
+++ b/tests/test_checkers.cpp
@@ -23,6 +23,7 @@ TEST_CASE("PairChecker Tests", "[checker]") {
         ChosenHand result = checker.Check(hand);
         REQUIRE(result.isValid() == true);
         REQUIRE(result.handName == "Pair");
+        REQUIRE(result.handType == PokerHandType::Pair);
     }
 
     SECTION("No Pair (High Card)") {
@@ -56,6 +57,7 @@ TEST_CASE("ThreeOfKindChecker Tests", "[checker]") {
         ChosenHand result = checker.Check(hand);
         REQUIRE(result.isValid() == true);
         REQUIRE(result.handName == "Three of a Kind");
+        REQUIRE(result.handType == PokerHandType::ThreeOfKind);
     }
 
     SECTION("Four of a Kind should not be Three of a Kind") {
@@ -108,11 +110,12 @@ TEST_CASE("Observer Pattern Tests - Joker Cards", "[observer]") {
 
 TEST_CASE("Strategy Pattern Tests - Rules", "[strategy]") {
     SECTION("Scoring Strategy") {
-        ScoringRule standardRule(std::make_unique<StandardScoring>());
-        REQUIRE(standardRule.calculateScore("Flush", 80) == 80);
-
-        ScoringRule doubleRule(std::make_unique<DoubleScoring>());
-        REQUIRE(doubleRule.calculateScore("Flush", 80) == 160);
+        HandScoreTable table;
+        table[PokerHandType::Flush] = HandScoreData(80, 4, 1);
+        
+        ScoringRule standardRule(std::make_unique<BaseScoringRule>());
+        PlayedHandResult result = standardRule.calculateScore(PokerHandType::Flush, table);
+        REQUIRE(result.finalScore == 320);
     }
 
     SECTION("Blind Strategy") {

--- a/tests/test_scoring.cpp
+++ b/tests/test_scoring.cpp
@@ -1,0 +1,58 @@
+#include "catch.hpp"
+#include "../src/lib/HandScore.h"
+#include "../src/lib/ScoringRule.h"
+#include "../src/lib/PokerHandType.h"
+
+TEST_CASE("Scoring Subsystem Tests", "[scoring]") {
+    HandScoreTable table;
+    table[PokerHandType::Pair] = HandScoreData(10, 2, 1);
+    table[PokerHandType::ThreeOfKind] = HandScoreData(30, 3, 1);
+    
+    ScoringRule scoringRule(std::make_unique<BaseScoringRule>());
+
+    SECTION("Pair lookup correctness") {
+        PlayedHandResult result = scoringRule.calculateScore(PokerHandType::Pair, table);
+        REQUIRE(result.handType == PokerHandType::Pair);
+        REQUIRE(result.chips == 10);
+        REQUIRE(result.mult == 2);
+        REQUIRE(result.level == 1);
+    }
+
+    SECTION("finalScore equals chips times mult") {
+        PlayedHandResult result = scoringRule.calculateScore(PokerHandType::ThreeOfKind, table);
+        REQUIRE(result.chips == 30);
+        REQUIRE(result.mult == 3);
+        REQUIRE(result.finalScore == 90);
+    }
+
+    SECTION("Planet-driven level upgrades") {
+        // Simulating a "planet-driven" upgrade by modifying the table
+        table[PokerHandType::Pair] = HandScoreData(15, 3, 2);
+        PlayedHandResult result = scoringRule.calculateScore(PokerHandType::Pair, table);
+        REQUIRE(result.level == 2);
+        REQUIRE(result.chips == 15);
+        REQUIRE(result.mult == 3);
+        REQUIRE(result.finalScore == 45);
+    }
+
+    SECTION("PlayedHandResult immutability") {
+        PlayedHandResult result = scoringRule.calculateScore(PokerHandType::Pair, table);
+        // The following lines would fail to compile if immutability was not enforced
+        // result.chips = 100; 
+        // result.finalScore = 1000;
+        
+        REQUIRE(result.chips == 10);
+        REQUIRE(result.finalScore == 20);
+        
+        // Confirming it's a value object with const members
+        static_assert(std::is_const<decltype(result.chips)>::value, "chips should be const");
+        static_assert(std::is_const<decltype(result.finalScore)>::value, "finalScore should be const");
+    }
+
+    SECTION("Unknown hand type returns zero score") {
+        PlayedHandResult result = scoringRule.calculateScore(PokerHandType::Flush, table);
+        REQUIRE(result.chips == 0);
+        REQUIRE(result.mult == 0);
+        REQUIRE(result.finalScore == 0);
+    }
+}


### PR DESCRIPTION
- Add PokerHandType enum and HandScoreData value objects
- Refactor ScoringRule to produce immutable PlayedHandResult
- Update all hand checkers to use explicit PokerHandType
- Decouple base scoring from Joker/deck state
- Add comprehensive scoring subsystem unit tests

Closes: scoring-subsystem-issue